### PR TITLE
theme: 검색 결과 페이지에 noindex 메타 추가

### DIFF
--- a/theme02/functions.php
+++ b/theme02/functions.php
@@ -45,6 +45,15 @@
   add_action( 'wp_enqueue_scripts', 'custom_theme_script' );
 
 
+  // 검색 결과 페이지 noindex 메타 태그
+  function custom_search_robots_meta() {
+    if ( is_search() ) {
+      echo '<meta name="robots" content="noindex,follow">';
+    }
+  }
+  add_action( 'wp_head', 'custom_search_robots_meta' );
+
+
   // 테마 서포트
   function custom_theme_setup() {
     add_theme_support( 'title-tag' );


### PR DESCRIPTION
### Motivation
- 검색 결과 페이지가 검색엔진에 색인되는 것을 방지하기 위해 `robots` 메타를 삽입하려는 목적입니다.

### Description
- `theme02/functions.php`에 `custom_search_robots_meta()` 함수를 추가하고 `wp_head` 훅에 연결하여 `is_search()`일 경우 `<meta name="robots" content="noindex,follow">`를 출력하도록 했습니다.
- PHP 문법과 기존 코드 스타일을 해치지 않도록 적용했습니다.

### Testing
- `php -l theme02/functions.php` 문법 검사는 통과했습니다.
- `git diff --check` 정적 검사도 통과했습니다.
- `npm run lint` 실행 시 `stylelint`가 지정된 SCSS 경로에 매칭되는 파일이 없어 `No files matching the pattern` 오류로 중단되어 린트 단계가 실패했습니다.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4c5f89db4c8326a45210be8fc95a86)